### PR TITLE
adding quite option to extract

### DIFF
--- a/solr.sh
+++ b/solr.sh
@@ -35,7 +35,7 @@ fi;
 
 # Exctracting apache solr from the zip file.
 if [ ! -d solr ]; then
-  unzip -o solr-4.7.2.zip
+  unzip -oq solr-4.7.2.zip
   mv solr-4.7.2 solr
 fi;
 


### PR DESCRIPTION
unzipping causes 3,000 unimportant outputs that no one cares about. Use -q flag to mute this.